### PR TITLE
Downgrade log level for empty connection messages

### DIFF
--- a/lib/Mojo/Server/FastCGI.pm
+++ b/lib/Mojo/Server/FastCGI.pm
@@ -110,7 +110,7 @@ sub read_request {
   # Type
   my ($type, $id, $body) = $self->read_record($c);
   unless ($type && $type eq 'BEGIN_REQUEST') {
-    $self->app->log->error("First FastCGI record wasn't a begin request.");
+    $self->app->log->info("First FastCGI record wasn't a begin request.");
     return;
   }
   $ENV{FCGI_ID} = $tx->{fcgi_id} = $id;
@@ -207,7 +207,7 @@ sub run {
 
     # Error
     unless ($tx) {
-      $self->app->log->error("No transaction for FastCGI request.");
+      $self->app->log->info("No transaction for FastCGI request.");
       next;
     }
 


### PR DESCRIPTION
We have our fastcgi processes polled fairly regularly to ensure they're still up. The polling consists of opening a connection, sending nothing, then disconnecting. This is filling the log file up with error messages that have very little value.

So this patch makes the log level used for these message "info" instead.

My thinking is that these aren't really errors from the server's perspective: the client sent bad data and it was rejected.
