### PR TITLE
Make the fastcgi module work with Mojolicious 3.0

### DIFF
--- a/lib/Mojolicious/Command/fastcgi.pm
+++ b/lib/Mojolicious/Command/fastcgi.pm
@@ -1,5 +1,5 @@
 package Mojolicious::Command::fastcgi;
-use Mojo::Base 'Mojo::Command';
+use Mojo::Base 'Mojolicious::Command';
 
 use Mojo::Server::FastCGI;
 


### PR DESCRIPTION
Mojo::Command ist now Mojolicious::Command
