### PR TITLE
fixed compatibility with mojolicious +3.21

### DIFF
--- a/lib/Mojolicious/Command/fastcgi.pm
+++ b/lib/Mojolicious/Command/fastcgi.pm
@@ -13,7 +13,7 @@ usage: $0 fastcgi
 EOF
 
 # "Interesting... Oh no wait, the other thing, tedious."
-sub run { Mojo::Server::FastCGI->new->run }
+sub run { Mojo::Server::FastCGI->new(app => shift->app)->run }
 
 1;
 __END__


### PR DESCRIPTION
In Issue #7, kraih writes:

I'm afraid in Mojolicious 3.21 we've had to change the way servers detect applications. Because, as it turns out, the trick we've used before is not actually a Perl feature and will stop working in all versions after 5.17.3. So, from now on you'll have to pass the application instance to the server in your fastcgi command.
